### PR TITLE
chore: update versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,32 +1,27 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.2.0
     hooks:
     -   id: check-yaml
 
--   repo: https://github.com/asottile/seed-isort-config
-    rev: v2.2.0
-    hooks:
-    -   id: seed-isort-config
-
 -   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.9.3
+    rev: v5.10.1
     hooks:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 21.10b0
+    rev: 22.3.0
     hooks:
       - id: black
         name: black
 
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 4.0.1
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910-1
+    rev: v0.961
     hooks:
     -   id: mypy
         additional_dependencies: [types-PyYAML, types-requests]

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ The ape-template plugin allows you to use cookiecutter to template an ape projec
 
 ## Dependencies
 
-* [python3](https://www.python.org/downloads) version 3.7.2 or greater, python3-dev
-* [cookiecutter](https://cookiecutter.readthedocs.io/en/2.0.2/) version 2.1.1
-* [eth-ape](https://docs.apeworx.io/ape/stable/) 0.3.0 or greater,
+* [python3](https://www.python.org/downloads) version 3.7 or greater, python3-dev
 
 ## Installation
 
@@ -36,19 +34,19 @@ Use `-h` to list all the commands.
 ape template -h
 ```
 
-Template use example
+To use the `template` command, provide either a GitHub repository ID or a raw URI:
 
 ```bash
 ape template gh:<github org>/<project>
 
 ape template <URI>
 ```
-[cookiecutter docs](https://cookiecutter.readthedocs.io/en/stable/)
+
+For more information on Cookiecutter, see their [documentation](https://cookiecutter.readthedocs.io/en/stable/).
 
 ## Development
 
-This project is in development and should be considered a beta.
-Things might not be in their final state and breaking changes may occur.
+Please see the [contributing guide](CONTRIBUTING.md) to learn more how to contribute to this project.
 Comments, questions, criticisms and pull requests are welcomed.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # ape-template
 
-TODO: Description
+The ape-template plugin allows you to use cookiecutter to template an ape project.
 
 ## Dependencies
 
-* [python3](https://www.python.org/downloads) version 3.7 or greater, python3-dev
-* [cookiecutter](https://cookiecutter.readthedocs.io/en/2.0.2/) version 1.7.3
-* [eth-ape](https://docs.apeworx.io/ape/stable/) 0.2.2 or greater, 
+* [python3](https://www.python.org/downloads) version 3.7.2 or greater, python3-dev
+* [cookiecutter](https://cookiecutter.readthedocs.io/en/2.0.2/) version 2.1.1
+* [eth-ape](https://docs.apeworx.io/ape/stable/) 0.3.0 or greater,
 
 ## Installation
 
@@ -30,7 +30,20 @@ python3 setup.py install
 
 ## Quick Usage
 
-TODO: Describe library overview in code
+Use `-h` to list all the commands.
+
+```bash
+ape template -h
+```
+
+Template use example
+
+```bash
+ape template gh:<github org>/<project>
+
+ape template <URI>
+```
+[cookiecutter docs](https://cookiecutter.readthedocs.io/en/stable/)
 
 ## Development
 

--- a/ape_template/_cli.py
+++ b/ape_template/_cli.py
@@ -1,2 +1,2 @@
 # flake8: noqa
-from cookiecutter.cli import main as cli
+from cookiecutter.cli import main as cli  # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,5 @@ markers = "fuzzing: Run Hypothesis fuzz test suite"
 line_length = 100
 force_grid_wrap = 0
 include_trailing_comma = true
-known_third_party = ["setuptools"]
-known_first_party = ["MODULE_NAME"]
 multi_line_output = 3
 use_parentheses = true

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,10 @@ extras_require = {
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
     ],
     "lint": [
-        "black>=21.10b0,<22.0",  # auto-formatter and linter
-        "mypy>=0.910,<1.0",  # Static type analyzer
-        "flake8>=3.8.3,<4.0",  # Style linter
-        "isort>=5.9.3,<6.0",  # Import sorting linter
+        "black>=22.3.0,<23.0",  # auto-formatter and linter
+        "mypy>=0.961,<1.0",  # Static type analyzer
+        "flake8>=4.0.1,<5.0",  # Style linter
+        "isort>=5.10.1,<6.0",  # Import sorting linter
     ],
     "release": [  # `release` GitHub Action job uses this
         "setuptools",  # Installation tool
@@ -21,7 +21,7 @@ extras_require = {
         "twine",  # Package upload tool
     ],
     "dev": [
-        "commitizen",  # Manage commits and publishing releases
+        "commitizen>=2.19,<2.20",  # Manage commits and publishing releases
         "pre-commit",  # Ensure that linters are run prior to commiting
         "pytest-watch",  # `ptw` test watcher/runner
         "IPython",  # Console for interacting
@@ -54,15 +54,15 @@ setup(
     include_package_data=True,
     install_requires=[
         "importlib-metadata ; python_version<'3.8'",
-        "cookiecutter>=1.7.3,<2.0.0",
-        "eth-ape>=0.2.2,<0.3.0",
+        "cookiecutter>=2.1.1,<2.2.0",
+        "eth-ape>=0.3.0,<0.4.0",
     ],  # NOTE: Add 3rd party libraries here
     entry_points={
         "ape_cli_subcommands": [
             "ape_template=ape_template._cli:cli",
         ],
     },
-    python_requires=">=3.7,<4",
+    python_requires=">=3.7.2,<4",
     extras_require=extras_require,
     py_modules=["ape_template"],
     license="Apache-2.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ from click.testing import CliRunner
 
 
 @pytest.fixture(scope="session")
-def ape_cli():
+def cli():
     from ape_template._cli import cli
 
     yield cli

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.fixture(scope="session")
+def ape_cli():
+    from ape_template._cli import cli
+
+    yield cli
+
+
+@pytest.fixture(scope="session")
+def runner():
+    yield CliRunner()

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -2,16 +2,21 @@ import shutil
 from pathlib import Path
 
 
-def test_template(runner, ape_cli):
+def test_template(runner, cli):
     project_path = Path("./TokenProject/")
 
     if project_path.exists():
         shutil.rmtree(project_path)
 
-    result = runner.invoke(ape_cli, ["gh:ApeAcademy/ERC20"], input="\n\n\n\n\n\n\n\n\n\n\n")
+    result = runner.invoke(cli, ["gh:ApeAcademy/ERC20"], input="\n\n\n\n\n\n\n\n\n\n\n")
     assert result.exit_code == 0
     assert project_path.exists()
     assert project_path.joinpath("contracts").exists()
     assert project_path.joinpath("scripts").exists()
     assert project_path.joinpath("tests").exists()
     shutil.rmtree(project_path)
+
+
+def test_help(runner, cli):
+    result = runner.invoke(cli, "--help")
+    assert result.exit_code == 0

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,0 +1,17 @@
+import shutil
+from pathlib import Path
+
+
+def test_template(runner, ape_cli):
+    project_path = Path("./TokenProject/")
+
+    if project_path.exists():
+        shutil.rmtree(project_path)
+
+    result = runner.invoke(ape_cli, ["gh:ApeAcademy/ERC20"], input="\n\n\n\n\n\n\n\n\n\n\n")
+    assert result.exit_code == 0
+    assert project_path.exists()
+    assert project_path.joinpath("contracts").exists()
+    assert project_path.joinpath("scripts").exists()
+    assert project_path.joinpath("tests").exists()
+    shutil.rmtree(project_path)


### PR DESCRIPTION
### What I did
Dependabot noted a security issue with cookiecutter, updated to 2.1.1
Updated eth-ape version to 0.3.0
Other small updates

fixes: #3 

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
